### PR TITLE
Changed names from motor_A motor_B to motor_this_way motor_that_way 

### DIFF
--- a/de/Arduino/Fritzing Creator Kit/Motor/Motor.ino
+++ b/de/Arduino/Fritzing Creator Kit/Motor/Motor.ino
@@ -1,33 +1,33 @@
 /*
   Motor
   dreht einen Motor erst rechts, dann links herum
-  
+
   Dieses Beispiel aus dem Fritzing Creator Kit: www.fritzing.org/creator-kit.
 */
 
-int motor_A=5;
-int motor_B=4;
+int motor_this_way=5;
+int motor_that_way=4;
 int motor_Speed=3;
 
 void setup(){
-  pinMode(motor_A,OUTPUT);
-  pinMode(motor_B,OUTPUT);
+  pinMode(motor_this_way,OUTPUT);
+  pinMode(motor_that_way,OUTPUT);
 }
 
 void loop(){
-  digitalWrite(motor_A,HIGH); 
-  digitalWrite(motor_B,LOW);
+  digitalWrite(motor_this_way,HIGH);
+  digitalWrite(motor_that_way,LOW);
   for (int i=0; i<256; i+=5){
-    analogWrite(motor_Speed,i); 
+    analogWrite(motor_Speed,i);
     delay(20);
   }
   for (int i=255; i>0; i-=5){
-    analogWrite(motor_Speed,i); 
+    analogWrite(motor_Speed,i);
     delay(20);
   }
 
-  digitalWrite(motor_A,LOW); 
-  digitalWrite(motor_B,HIGH);
+  digitalWrite(motor_this_way,LOW);
+  digitalWrite(motor_that_way,HIGH);
   for (int i=0; i<256; i+=5){
     analogWrite(motor_Speed,i);
     delay(20);

--- a/en/Arduino/Fritzing Creator Kit/Motor/Motor.ino
+++ b/en/Arduino/Fritzing Creator Kit/Motor/Motor.ino
@@ -1,23 +1,23 @@
 /*
   Motor
   turning a motor clock then counter clock wise
-  
+
   This example is part of the Fritzing Creator Kit: www.fritzing.org/creatorkit.
 */
 
-int motor_A=6;                    // motor A Pin
-int motor_B=5;                    // motor B Pin
+int motor_this_way=6;                    // motor A Pin
+int motor_that_way=5;                    // motor B Pin
 int motor_Speed=3;                // speed Pin
 
 void setup(){
-  pinMode(motor_A,OUTPUT);        // pin A declared as OUTPUT
-  pinMode(motor_B,OUTPUT);        // pin B declared as OUTPUT
+  pinMode(motor_this_way,OUTPUT);        // pin A declared as OUTPUT
+  pinMode(motor_that_way,OUTPUT);        // pin B declared as OUTPUT
 }
 
 void loop(){
-  digitalWrite(motor_A,HIGH);     // motor A pin switched to HIGH (+5V)
-  digitalWrite(motor_B,LOW);      // motor B pin switched to LOW  (GND)
-  for (int i=0; i<256; i+=5){     // count up to 255 in steps of five 
+  digitalWrite(motor_this_way,HIGH);     // motor A pin switched to HIGH (+5V)
+  digitalWrite(motor_that_way,LOW);      // motor B pin switched to LOW  (GND)
+  for (int i=0; i<256; i+=5){     // count up to 255 in steps of five
     analogWrite(motor_Speed,i);   // and write it as speed to the speed pin
     delay(20);                    // wait 20 ms
   }
@@ -26,9 +26,9 @@ void loop(){
     delay(20);                   // wait 20 ms
   }
 
-  digitalWrite(motor_A,LOW);     // motor A pin switched to HIGH (GND) 
-  digitalWrite(motor_B,HIGH);    // motor B pin switched to LOW  (+5V)
-  for (int i=0; i<256; i+=5){    // count up to 255 in steps of five 
+  digitalWrite(motor_this_way,LOW);     // motor A pin switched to HIGH (GND)
+  digitalWrite(motor_that_way,HIGH);    // motor B pin switched to LOW  (+5V)
+  for (int i=0; i<256; i+=5){    // count up to 255 in steps of five
     analogWrite(motor_Speed,i);  // and write it as speed to the speed pin
     delay(20);                   // wait 20 ms
   }


### PR DESCRIPTION
When using these examples we found it clearer with these names when using these sketches @FH-Potsdam
The names motor_A and motor_B lead us to think that we are using 2 motors. Not one motor with two directions.  
modified:   de/Arduino/Fritzing Creator Kit/Motor/Motor.ino
modified:   en/Arduino/Fritzing Creator Kit/Motor/Motor.ino
